### PR TITLE
Pin OpenScale version to 1.0.429 .

### DIFF
--- a/examples/AIopenScaleAndAzureMLengineExampleOutput.ipynb
+++ b/examples/AIopenScaleAndAzureMLengineExampleOutput.ipynb
@@ -88,7 +88,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {

--- a/notebooks/AIopenScaleAndAzureMLengine.ipynb
+++ b/notebooks/AIopenScaleAndAzureMLengine.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {


### PR DESCRIPTION
New notebook for version 2.x will follow after testing and updates
for new data set.
This is a workaround.