### PR TITLE
Update notebook for new PyPi version of OpenScale

### DIFF
--- a/notebooks/WatsonOpenScaleAndAzureMLengine.ipynb
+++ b/notebooks/WatsonOpenScaleAndAzureMLengine.ipynb
@@ -75,35 +75,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> NOTE: Below cell is a temporary fix as of 2/25/2019. Remove it and this comment, and un-comment regular `pip install ibm-ai-openscale==2.2.0.29` when that becomes valid."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -i https://test.pypi.org/simple/ ibm-ai-openscale==2.1.0.29"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> NOTE: ibm-ai-openscale is not on PyPi as of 2/25/2019. When it is, uncomment below and run that instead of cell above"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#!pip install ibm-ai-openscale==2.1.0.29 --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==2.1.1 --no-cache | tail -n 1"
    ]
   },
   {


### PR DESCRIPTION
Notebook points to https://test.pypi.org/simple/ for ibm-ai-openscale
package. Remove this cell and comments surrounding it.

Closes: #16